### PR TITLE
Comma Escaping for MFG_NAME

### DIFF
--- a/bom-ex.ulp
+++ b/bom-ex.ulp
@@ -2162,6 +2162,24 @@ int ExportGeneric()
     return records;
 }
 
+
+//////////////////////////////////////////////////////////////////////////////
+// str_replace
+//
+// Replaces all occurrences of a substring found within a string.
+
+string str_replace(string search, string replace, string subject) {
+    int lastpos = 0;
+    while(strstr(subject, search, lastpos) >= 0) {
+        int pos = strstr(subject, search, lastpos);
+        string before = strsub(subject, 0, pos);
+        string after = strsub(subject, pos + strlen(search));
+        subject = before + replace + after;
+        lastpos = pos + strlen(replace);
+    }
+    return subject;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Export a Digi-Key format upload BOM in CSV or TAB format
 //
@@ -2370,7 +2388,7 @@ int ExportDigiKey()
             if ((vendor_id == "DK") || (vendor_id == nullKey))
             {
                 printf("%s%s", partno_dk, delimit);
-                printf("%s%s", mfg_name, delimit);
+                printf("%s%s", str_replace(",", "", mfg_name), delimit);
                 printf("%s%s", part_num, delimit);
                 printf("%s%s", cust_ref, delimit);
                 printf("%s%s", quantity1, delimit);


### PR DESCRIPTION
Added a string replace function from https://github.com/xdissent/monowave-eagle/blob/master/User%20Language%20Programs/Library%20Browser/Process%20Library.ulp.

It is used to escape potential commas in manufacturer names such as "Samsung Electronics, Inc" which was requiring manual cleanup before import to Digikey.

_Note: Digikey does not respect the full CSV spec as they just break on all commas, this means just quoting each field does not work_
