### PR TITLE
Update bom-ex.ulp, problem with sheet 0

### DIFF
--- a/bom-ex.ulp
+++ b/bom-ex.ulp
@@ -674,13 +674,13 @@ void CollectPartData(string var)
             // Module instances
             if (P.modulepart) {
                 P.modulepart.instances(I)
-                    AddPartData(P, I);
+                if(I.sheet!=0) AddPartData(P, I);
             }
             else
             {
                 // Sheet instances
                 P.instances(I)            
-                    AddPartData(P, I);
+                if(I.sheet!=0) AddPartData(P, I);
             }
         }
     }


### PR DESCRIPTION
When a device has symbols that you can invoke, but there aren't in the board, it's possible that the script find this part and since it isn't added it shows the symbol in sheet 0.

Since allparts also show an entry to the invoked parts also, we can simply ignore the symbols without sheet, so that the generated script don't generate error in Eagle (EDIT .s0 closes the schematic)