### PR TITLE
feat(bom-ex): add checkbox to exclude DNP parts from BOM

### DIFF
--- a/bom-ex.ulp
+++ b/bom-ex.ulp
@@ -378,6 +378,7 @@ int ListType            = ltParts;
 int OutputFormat        = ofText;
 int ApplyAllAttrs       = 0;
 int ShowExcludedParts   = 0;
+int HideDNPParts        = 0;
 
 string DefaultFileName;
 
@@ -564,8 +565,12 @@ void AddPartData(UL_PART P, UL_INSTANCE I)
         string desc    = "";
         int qty        = 0;
 
-        if (!P.populate)
+        if (!P.populate) {
             dnp = 1;
+            if (HideDNPParts && !ShowExcludedParts) {
+                exclude = 1;
+            }
+        }
         
         P.attributes(A)
         {
@@ -603,8 +608,12 @@ void AddPartData(UL_PART P, UL_INSTANCE I)
             else if (aname == "DNP")
             {
                 // Exclude part from BOM?
-                if (avalue == "T")
+                if (avalue == "T") {
                     dnp = 1;
+                    if (HideDNPParts && !ShowExcludedParts) {
+                        exclude = 1;
+                    }
+                }
             }
             else if (aname == "QTY")
             {
@@ -3820,6 +3829,7 @@ int AppDialog()
                     {
                         dlgCheckBox("Apply part number attributes globally", ApplyAllAttrs);
                         dlgCheckBox("Show Excluded Parts", ShowExcludedParts) OnVariantComboChange();                        
+                        dlgCheckBox("Hide DNP Parts", HideDNPParts) OnVariantComboChange();
                     }
                 }                
             }


### PR DESCRIPTION
Excludes DNP parts from the BOM when selected. Tested and working for both "DNP" attributes and assembly variants